### PR TITLE
patch/hostport Removed use on host port manager

### DIFF
--- a/contrib/test/integration/build/runc.yml
+++ b/contrib/test/integration/build/runc.yml
@@ -4,7 +4,7 @@
   git:
     repo: "https://github.com/opencontainers/runc.git"
     dest: "{{ ansible_env.GOPATH }}/src/github.com/opencontainers/runc"
-    version: "HEAD"
+    version: "v1.0.1"
 
 - name: build runc
   make:

--- a/scripts/github-actions-setup
+++ b/scripts/github-actions-setup
@@ -58,6 +58,7 @@ install_critools() {
 
     git clone $URL
     pushd cri-tools
+    git checkout "${VERSIONS["cri-tools"]}"
     sudo -E PATH="$PATH" make BINDIR=/usr/bin install
     popd
     sudo rm -rf cri-tools

--- a/server/server.go
+++ b/server/server.go
@@ -19,7 +19,6 @@ import (
 	imageTypes "github.com/containers/image/v5/types"
 	"github.com/containers/storage/pkg/idtools"
 	storageTypes "github.com/containers/storage/types"
-	"github.com/cri-o/cri-o/internal/hostport"
 	"github.com/cri-o/cri-o/internal/lib"
 	"github.com/cri-o/cri-o/internal/lib/sandbox"
 	"github.com/cri-o/cri-o/internal/log"
@@ -57,9 +56,8 @@ type StreamService struct {
 
 // Server implements the RuntimeService and ImageService
 type Server struct {
-	config          libconfig.Config
-	stream          StreamService
-	hostportManager hostport.HostPortManager
+	config libconfig.Config
+	stream StreamService
 
 	*lib.ContainerServer
 	monitorsChan      chan struct{}
@@ -397,8 +395,6 @@ func New(
 		return nil, err
 	}
 
-	hostportManager := hostport.NewMetaHostportManager()
-
 	idMappings, err := getIDMappings(config)
 	if err != nil {
 		return nil, err
@@ -412,7 +408,6 @@ func New(
 
 	s := &Server{
 		ContainerServer:          containerServer,
-		hostportManager:          hostportManager,
 		config:                   *config,
 		monitorsChan:             make(chan struct{}),
 		defaultIDMappings:        idMappings,


### PR DESCRIPTION
Port mapping functionality now left only for plugins.
Added runtime config for port mapping to be used by plugins.

CRIO port mapping functionality has some know issues (CSCvy83719).
CRIO does not have any way to disable hostport mapping feature,
hence removing this feature from code to facilitate use of plugins.

