### PR TITLE
patch/hostport Removed use on host port manager

### DIFF
--- a/server/sandbox_network.go
+++ b/server/sandbox_network.go
@@ -8,15 +8,12 @@ import (
 
 	cnitypes "github.com/containernetworking/cni/pkg/types"
 	cnicurrent "github.com/containernetworking/cni/pkg/types/current"
-	"github.com/cri-o/cri-o/internal/hostport"
 	"github.com/cri-o/cri-o/internal/lib/sandbox"
 	"github.com/cri-o/cri-o/internal/log"
 	"github.com/cri-o/cri-o/server/metrics"
 	"github.com/cri-o/ocicni/pkg/ocicni"
 	"github.com/pkg/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
-
-	utilnet "k8s.io/utils/net"
 )
 
 // networkStart sets up the sandbox's network and returns the pod IP on success
@@ -74,48 +71,12 @@ func (s *Server) networkStart(ctx context.Context, sb *sandbox.Sandbox) (podIPs 
 		return nil, nil, fmt.Errorf("failed to get network JSON for pod sandbox %s(%s): %v", sb.Name(), sb.ID(), err)
 	}
 
-	// only do portmapping to the first IP of each IP family
-	foundIPv4 := false
-	foundIPv6 := false
-	// cache the portmapping info
-	sbID := sb.ID()
-	sbName := sb.Name()
-	sbPortMappings := sb.PortMappings()
 	// iterate over each IP and add the portmap if needed
 	for _, podIPConfig := range network.IPs {
 		ip := podIPConfig.Address.IP
 		podIPs = append(podIPs, ip.String())
-
-		// the pod has host-ports defined
-		if len(sbPortMappings) > 0 {
-			mapping := &hostport.PodPortMapping{
-				Name:         sbName,
-				PortMappings: sbPortMappings,
-				IP:           ip,
-				HostNetwork:  false,
-			}
-			// nolint:gocritic // using a switch statement is not much different
-			if utilnet.IsIPv6(ip) {
-				if foundIPv6 {
-					// we have already done the portmap for IPv6
-					continue
-				}
-				// found a new IPv6 address, do the portmap
-				foundIPv6 = true
-			} else if foundIPv4 {
-				// we have already done the portmap for IPv4
-				continue
-			} else {
-				// found a new IPv4 address, do the portmap
-				foundIPv4 = true
-			}
-			err = s.hostportManager.Add(sbID, mapping, "")
-			if err != nil {
-				return nil, nil, fmt.Errorf("failed to add hostport mapping for sandbox %s(%s): %v", sb.Name(), sb.ID(), err)
-			}
-		}
+		log.Infof(ctx, "skipped use of hostport manager add...")
 	}
-
 	log.Debugf(ctx, "Found POD IPs: %v", podIPs)
 
 	// metric about the whole network setup operation
@@ -161,16 +122,7 @@ func (s *Server) networkStop(ctx context.Context, sb *sandbox.Sandbox) error {
 	stopCtx, stopCancel := context.WithTimeout(ctx, 1*time.Minute)
 	defer stopCancel()
 
-	mapping := &hostport.PodPortMapping{
-		Name:         sb.Name(),
-		PortMappings: sb.PortMappings(),
-		HostNetwork:  false,
-	}
-	// portMapping removal does not need the IP address
-	if err := s.hostportManager.Remove(sb.ID(), mapping); err != nil {
-		log.Warnf(ctx, "Failed to remove hostport for pod sandbox %s(%s): %v",
-			sb.Name(), sb.ID(), err)
-	}
+	log.Infof(ctx, "skipped use of hostport manager remove...")
 
 	podNetwork, err := s.newPodNetwork(sb)
 	if err != nil {
@@ -217,6 +169,21 @@ func (s *Server) newPodNetwork(sb *sandbox.Sandbox) (ocicni.PodNetwork, error) {
 		}
 	}
 
+	// Pass along sandbox port mapping info.
+	var portMappings []ocicni.PortMapping
+	sbPortMappings := sb.PortMappings()
+	for _, pm := range sbPortMappings {
+		if pm.ContainerPort == 0 {
+			continue
+		}
+		portMap := ocicni.PortMapping{
+			HostPort:      pm.HostPort,
+			ContainerPort: pm.ContainerPort,
+			Protocol:      string(pm.Protocol),
+		}
+		portMappings = append(portMappings, portMap)
+	}
+
 	network := s.config.CNIPlugin().GetDefaultNetworkName()
 	return ocicni.PodNetwork{
 		Name:      sb.KubeName(),
@@ -226,7 +193,7 @@ func (s *Server) newPodNetwork(sb *sandbox.Sandbox) (ocicni.PodNetwork, error) {
 		ID:        sb.ID(),
 		NetNS:     sb.NetNsPath(),
 		RuntimeConfig: map[string]ocicni.RuntimeConfig{
-			network: {Bandwidth: bwConfig},
+			network: {Bandwidth: bwConfig, PortMappings: portMappings},
 		},
 	}, nil
 }

--- a/server/server.go
+++ b/server/server.go
@@ -19,7 +19,6 @@ import (
 	imageTypes "github.com/containers/image/v5/types"
 	"github.com/containers/storage/pkg/idtools"
 	storageTypes "github.com/containers/storage/types"
-	"github.com/cri-o/cri-o/internal/hostport"
 	"github.com/cri-o/cri-o/internal/lib"
 	"github.com/cri-o/cri-o/internal/lib/sandbox"
 	"github.com/cri-o/cri-o/internal/log"
@@ -57,9 +56,8 @@ type StreamService struct {
 
 // Server implements the RuntimeService and ImageService
 type Server struct {
-	config          libconfig.Config
-	stream          StreamService
-	hostportManager hostport.HostPortManager
+	config libconfig.Config
+	stream StreamService
 
 	*lib.ContainerServer
 	monitorsChan      chan struct{}
@@ -397,8 +395,6 @@ func New(
 		return nil, err
 	}
 
-	hostportManager := hostport.NewMetaHostportManager()
-
 	idMappings, err := getIDMappings(config)
 	if err != nil {
 		return nil, err
@@ -412,7 +408,6 @@ func New(
 
 	s := &Server{
 		ContainerServer:          containerServer,
-		hostportManager:          hostportManager,
 		config:                   *config,
 		monitorsChan:             make(chan struct{}),
 		defaultIDMappings:        idMappings,


### PR DESCRIPTION
Port mapping functionality now left only for plugins.
Added runtime config for port mapping to be used by plugins.

CRIO port mapping functionality has some know issues (CSCvy83719).
CRIO does not have any way to disable hostport mapping feature,
hence removing this feature from code to facilitate use of plugins.

<!--  Thanks for sending a pull request!

Please be aware that we're following the Kubernetes guidelines of contributing
to this project. This means that we have to use this mandatory template for all
of our pull requests.

Please also make sure you've read and understood our contributing guidelines
(https://github.com/cri-o/cri-o/blob/main/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.

Here are some additional tips for you:

- If this is your first time, please read our contributor guidelines:
  https://git.k8s.io/community/contributors/guide#your-first-contribution and
  developer guide
  https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are
  addressing, especially if this is a release targeted pull request. For
  reference on required PR/issue labels, read here:
  https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

<!--
/kind api-change
/kind bug
/kind ci
/kind cleanup
/kind dependency-change
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake
/kind other
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note

```
